### PR TITLE
Drop unused TravisCI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: ruby
-rvm:
-  - 1.8.7
-  - jruby-18mode
-  - 1.9.3
-  - jruby-19mode
-  - 2.1.0
-  - rbx


### PR DESCRIPTION
README could get a new badge, too.